### PR TITLE
(DOCSP-50765): Fix spacing issue in removeCodeBlocks command

### DIFF
--- a/src/commands/removeCodeBlocks.ts
+++ b/src/commands/removeCodeBlocks.ts
@@ -309,7 +309,7 @@ const makeLiteralincludeFilePath = (
 };
 
 /**
- * Write the code blocks from the page to files of the appropriate type at the appropriate location in the `untested-files` directory
+ * Write the code blocks from the page to files of the appropriate type at the appropriate location in the `code-examples` directory
  *
  * @param pageWriteData - Data required to write the code blocks to file, including path info, directory info, and the code block content
  */
@@ -357,17 +357,14 @@ const makeCodeBlockDirectoryFromPageFilepath = (filepath: string): string => {
     pathSegments.length > 1 ? pathSegments.slice(1) : [];
   // Join the remaining segments back into a path
   const pathMinusStartDir = `${path.sep}${removedFirstSegment.join(path.sep)}`;
-  console.log(`Path minus start dir is: ${pathMinusStartDir}`);
   const baseName = path.basename(filepath);
   const extension = path.extname(filepath);
-  const untestedDir = "untested-examples";
+  const untestedDir = "code-examples";
   const codeBlockPageDir = baseName.replace(extension, "");
-  console.log(`Code block page dir is: ${codeBlockPageDir}`);
   const relPathIncludingSubdirs = pathMinusStartDir.replace(
     baseName,
     codeBlockPageDir
   );
-  console.log(`Rel path including subdirs is: ${codeBlockPageDir}`);
   return path.join(untestedDir, relPathIncludingSubdirs);
 };
 
@@ -404,8 +401,8 @@ async function walkDirectory(
     const stats = await fs.stat(entryPath);
 
     if (stats.isDirectory()) {
-      // We don't want to process any files in the 'untested-examples' directory
-      if (entryPath.includes("untested-examples")) {
+      // We don't want to process any files in the 'code-examples' directory
+      if (entryPath.includes("code-examples")) {
         continue;
       }
       await walkDirectory(entryPath, callback); // Recurse into subdirectory

--- a/src/commands/removeCodeBlocks.ts
+++ b/src/commands/removeCodeBlocks.ts
@@ -162,15 +162,12 @@ export const getFormattedCodeBlockTextFromDirective = (
   // Collect the remaining lines starting from the first non-meta line
   const remainingLines = lines.slice(index);
   const trimmedLines: string[] = [];
-  let isFirstLine = true;
-  let indentOffset = 0;
-  for (const line of remainingLines) {
+  if (remainingLines.length > 0) {
     // Calculate the offset for whitespace from the first line. Remove the same N character count from that and every subsequent line.
-    if (isFirstLine) {
-      indentOffset = countLeadingWhitespace(line);
-      isFirstLine = false;
-    }
-    trimmedLines.push(trimLeadingNSpaces(line, indentOffset));
+    const indentOffset = countLeadingWhitespace(remainingLines[0]);
+    trimmedLines.push(
+      ...remainingLines.map((line) => trimLeadingNSpaces(line, indentOffset))
+    );
   }
 
   // Return the remaining lines joined back into a string

--- a/src/commands/removeCodeBlocks.ts
+++ b/src/commands/removeCodeBlocks.ts
@@ -135,7 +135,6 @@ export const removeCodeBlocks = async (
 /**
  * Remove the code block directive and option lines, and get only the code text itself
  * @param inputString - The entirety of the code block directive, including the `.. code-block::` directive start and code content
- * @param indentWidth - The start column of the code block text, to properly adjust the offset to un-indent nested content
  */
 export const getFormattedCodeBlockTextFromDirective = (
   inputString: string

--- a/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/1.sh
+++ b/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/1.sh
@@ -1,0 +1,1 @@
+https://github.com/realm/realm-swift.git

--- a/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/1.txt
+++ b/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/1.txt
@@ -1,0 +1,17 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'MyRealmProject' do
+# Comment the next line if you don't want to use dynamic frameworks
+use_frameworks!
+
+# Pods for MyRealmProject
+pod 'Realm', '~>10'
+
+target 'MyRealmProjectTests' do
+   inherit! :search_paths
+   # Pods for testing
+   pod 'Realm', '~>10'
+end
+
+end

--- a/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/2.sh
+++ b/src/commands/test/removeCodeBlocks/source/code-examples/arbitrary-dir-name/file/2.sh
@@ -1,0 +1,1 @@
+npm install docdoctor


### PR DESCRIPTION
Found a spacing issue with code block text output related to code examples nested in other directives. This PR fixes this issue by counting arbitrary whitespace at the beginning of a code block text string, and removing that many characters from each line in the code block.

Jira ticket where the issue is described: https://jira.mongodb.org/browse/DOCSP-50765

Per JD, we also don't want to use the `untested-examples` name in the monorepo, since it is copied out to a public repo, so rename the output dir to `code-examples`.